### PR TITLE
Avoid `#attr_name_options` returning invalid key/value pairs

### DIFF
--- a/lib/enum_i18n_help/enum_i18n.rb
+++ b/lib/enum_i18n_help/enum_i18n.rb
@@ -33,7 +33,12 @@ module EnumI18nHelp
 
         klass.instance_eval <<-METHOD, __FILE__, __LINE__ + 1
         def #{attr_name}_options
-          #{attr_value_hash}.merge((I18n.t "activerecord.attributes.#{klass.name.underscore}/#{attr_name}").reject{ |_, v| v.nil? }).invert.to_a
+          locale_definitions = I18n.t("activerecord.attributes.#{klass.name.underscore}/#{attr_name}")
+
+          #{attr_value_hash}
+            .merge(locale_definitions.reject{ |k, v| v.nil? || #{attr_value.keys}.exclude?(k.to_sym) })
+            .invert
+            .to_a
         end
         METHOD
       end

--- a/spec/enum_i18n_help_spec.rb
+++ b/spec/enum_i18n_help_spec.rb
@@ -90,6 +90,7 @@ RSpec.describe EnumI18nHelp::EnumI18n do
 
       it { expect(I18n.locale).to eq :ja }
       it { is_expected.to eq [["男性", :man], ["女性", :woman], ["Nothing", :nothing]] }
+      it { is_expected.not_to include ['ghost_enum_key', 'User modelのenum定義に存在しないキー'] }
     end
 
     context 'lang is en' do
@@ -97,6 +98,7 @@ RSpec.describe EnumI18nHelp::EnumI18n do
 
       it { expect(I18n.locale).to eq :en }
       it { is_expected.to eq [["Man", :man], ["Woman", :woman], ["Nothing", :nothing]] }
+      it { is_expected.not_to include ['ghost_enum_key', 'This key does not exist in User model\'s enum definition'] }
     end
   end
 end

--- a/spec/fixtures/locales/en.yml
+++ b/spec/fixtures/locales/en.yml
@@ -4,4 +4,4 @@ en:
       user/sex:
         man: Man
         woman: Woman
-        none:
+        nothing:

--- a/spec/fixtures/locales/en.yml
+++ b/spec/fixtures/locales/en.yml
@@ -5,3 +5,4 @@ en:
         man: Man
         woman: Woman
         nothing:
+        ghost_enum_key: This key does not exist in User model's enum definition

--- a/spec/fixtures/locales/ja.yml
+++ b/spec/fixtures/locales/ja.yml
@@ -5,3 +5,4 @@ ja:
         man: 男性
         woman: 女性
         nothing:
+        ghost_enum_key: User modelのenum定義に存在しないキー

--- a/spec/fixtures/locales/ja.yml
+++ b/spec/fixtures/locales/ja.yml
@@ -4,4 +4,4 @@ ja:
       user/sex:
         man: 男性
         woman: 女性
-        none:
+        nothing:


### PR DESCRIPTION
1. Rename wrong locale key (from `none` to `nothing`)
2. Exclude invalid key/value pairs which are not defined in model's enum definition from `#attr_name_options`'s return value