### PR TITLE
Update bundler version to pass Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 rvm:
-  - 2.2.9
   - 2.3.5
   - 2.4.3
   - 2.5.0
 before_install:
   - gem update --system
-  - gem install bundler -v 1.16.1
+  - gem install bundler -v 2.1.4
 cache: bundler

--- a/enum_i18n_help.gemspec
+++ b/enum_i18n_help.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activerecord", "~> 5.0"
 
   spec.add_development_dependency "activesupport", "~> 5.0"
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
1. Change bundler version to 2.1.4 in order to let build pass
2. Remove Ruby version `2.2.9` since `rubygems-update-3.1.4.gem` requires Ruby >=2.3.0