### PR TITLE
Remove the activerecord version specification

### DIFF
--- a/enum_i18n_help.gemspec
+++ b/enum_i18n_help.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord", "~> 5.0"
+  spec.add_runtime_dependency "activerecord"
 
   spec.add_development_dependency "activesupport", "~> 5.0"
   spec.add_development_dependency "bundler", "~> 2.1.4"


### PR DESCRIPTION
Remove activerecord version `~> 5.0` since rails `(~> 6.0.3)` depends on activerecord `(~> 6.0.3.2)`