### PR TITLE
Fix #enum_key_text : return nil when enum value is nil

### DIFF
--- a/lib/enum_i18n_help/enum_i18n.rb
+++ b/lib/enum_i18n_help/enum_i18n.rb
@@ -22,6 +22,8 @@ module EnumI18nHelp
       def define_text_method!(klass, enum_key)
         klass.class_eval <<-METHOD, __FILE__, __LINE__ + 1
         def #{enum_key}_text
+          return if #{enum_key}.nil?
+
           I18n.t "activerecord.attributes.#{klass.name.underscore}/#{enum_key}." + #{enum_key}, default: #{enum_key}.humanize
         end
         METHOD

--- a/spec/enum_i18n_help_spec.rb
+++ b/spec/enum_i18n_help_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 class User < ActiveRecord::Base
   include EnumI18nHelp::EnumI18n
   enum sex: { man: 0, woman: 1, nothing: 2 }
+  enum job: %i[engineer designer journalist]
 end
 
 class Article < ActiveRecord::Base
@@ -34,50 +35,90 @@ RSpec.describe EnumI18nHelp::EnumI18n do
   end
 
   describe '#enum_key_text' do
-    let(:user) { User.create(sex: sex) }
-    let(:sex) { 'man' }
+    describe 'user.sex' do
+      let(:user) { User.create(sex: sex) }
+      let(:sex) { 'man' }
 
-    subject { user.sex_text }
+      subject { user.sex_text }
 
-    context 'lang is ja' do
-      before { I18n.locale = :ja }
+      context 'lang is ja' do
+        before { I18n.locale = :ja }
 
-      it { expect(I18n.locale).to eq :ja }
+        it { expect(I18n.locale).to eq :ja }
 
-      context 'sex is man' do
-        let(:sex) { 'man' }
-        it { is_expected.to eq '男性' }
+        context 'sex is man' do
+          let(:sex) { 'man' }
+          it { is_expected.to eq '男性' }
+        end
+
+        context 'sex is woman' do
+          let(:sex) { 'woman' }
+          it { is_expected.to eq '女性' }
+        end
+
+        context 'do not have translated words' do
+          let(:sex) { 'nothing' }
+          it { is_expected.to eq 'Nothing' }
+        end
       end
 
-      context 'sex is woman' do
-        let(:sex) { 'woman' }
-        it { is_expected.to eq '女性' }
-      end
+      context 'lang is en' do
+        before { I18n.locale = :en }
 
-      context 'do not have translated words' do
-        let(:sex) { 'nothing' }
-        it { is_expected.to eq 'Nothing' }
+        it { expect(I18n.locale).to eq :en }
+
+        context 'sex is man' do
+          let(:sex) { 'man' }
+          it { is_expected.to eq 'Man' }
+        end
+
+        context 'sex is woman' do
+          let(:sex) { 'woman' }
+          it { is_expected.to eq 'Woman' }
+        end
+
+        context 'do not have translated words' do
+          let(:sex) { 'nothing' }
+          it { is_expected.to eq 'Nothing' }
+        end
       end
     end
 
-    context 'lang is en' do
-      before { I18n.locale = :en }
+    describe 'user.job' do
+      let(:user) { User.create(sex: 'man', job: job) }
 
-      it { expect(I18n.locale).to eq :en }
+      subject { user.job_text }
 
-      context 'sex is man' do
-        let(:sex) { 'man' }
-        it { is_expected.to eq 'Man' }
+      context 'lang is ja' do
+        before { I18n.locale = :ja }
+
+        it { expect(I18n.locale).to eq :ja }
+
+        context 'job is engineer' do
+          let(:job) { 'engineer' }
+          it { is_expected.to eq 'エンジニア' }
+        end
+
+        context 'job is nil' do
+          let(:job) { nil }
+          it { is_expected.to eq nil }
+        end
       end
 
-      context 'sex is woman' do
-        let(:sex) { 'woman' }
-        it { is_expected.to eq 'Woman' }
-      end
+      context 'lang is en' do
+        before { I18n.locale = :en }
 
-      context 'do not have translated words' do
-        let(:sex) { 'nothing' }
-        it { is_expected.to eq 'Nothing' }
+        it { expect(I18n.locale).to eq :en }
+
+        context 'job is engineer' do
+          let(:job) { 'engineer' }
+          it { is_expected.to eq 'Engineer' }
+        end
+
+        context 'job is nil' do
+          let(:job) { nil }
+          it { is_expected.to eq nil }
+        end
       end
     end
   end

--- a/spec/fixtures/locales/en.yml
+++ b/spec/fixtures/locales/en.yml
@@ -6,3 +6,7 @@ en:
         woman: Woman
         nothing:
         ghost_enum_key: This key does not exist in User model's enum definition
+      user/job:
+        engineer: Engineer
+        designer: Designer
+        journalist: Journalist

--- a/spec/fixtures/locales/ja.yml
+++ b/spec/fixtures/locales/ja.yml
@@ -6,3 +6,7 @@ ja:
         woman: 女性
         nothing:
         ghost_enum_key: User modelのenum定義に存在しないキー
+      user/job:
+        engineer: エンジニア
+        designer: デザイナー
+        journalist: ジャーナリスト

--- a/spec/support/setup_database.rb
+++ b/spec/support/setup_database.rb
@@ -5,6 +5,7 @@ class CreateAllTables < ActiveRecord::Migration[5.0]
   def change
     create_table :users do |t|
       t.integer :sex, null: false, limit: 1
+      t.integer :job, null: true, limit: 1
 
       t.timestamps
     end


### PR DESCRIPTION
## Current behaviour
When enum value is nil, `TypeError` is raised like this:

```ruby
  def #{enum_key}_text
    I18n.t "activerecord.attributes.#{klass.name.underscore}/#{enum_key}." + #{enum_key}, default: #{enum_key}.humanize

     TypeError:
       no implicit conversion of nil into String
     # ./lib/enum_i18n_help/enum_i18n.rb:27:in `+'
     # ./lib/enum_i18n_help/enum_i18n.rb:27:in `job_text'
     # ./spec/enum_i18n_help_spec.rb:90:in `block (4 levels) in <top (required)>'
     # ./spec/enum_i18n_help_spec.rb:104:in `block (6 levels) in <top (required)>'
```

## Expected behaviour:
When enum value is nil, no error should be raised, and `#enum_key_text` should return nil;
since it is possible that enum attribute such as `user.sex`, `article.status` allows nil

## Changes in this PR:
- Let `#enum_key_text` return nil when enum value is nil
- Add corresponding rspec cases and locales